### PR TITLE
Bug Fix: Do not update focus on popped views

### DIFF
--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -121,7 +121,7 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
     _hitTestEdgeInsets = UIEdgeInsetsZero;
 
     _backgroundColor = super.backgroundColor;
-    
+
     _tvParallaxDisable = false;
     _tvParallaxShiftDistanceX = 2.0f;
     _tvParallaxShiftDistanceY = 2.0f;
@@ -328,7 +328,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
     self.motionEffects = @[xShift, yShift, xTilt, yTilt];
 
     float magnification = self.tvParallaxMagnification;
-  
+
     [UIView animateWithDuration:0.2 animations:^{
         self.transform = CGAffineTransformMakeScale(magnification, magnification);
     }];
@@ -368,15 +368,16 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   if(hasTVPreferredFocus) {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
       UIView *rootview = self;
-      while(![rootview isReactRootView]) {
+      while(![rootview isReactRootView] && rootview != nil) {
         rootview = [rootview superview];
       }
-      rootview = [rootview superview];
+      if(rootview == nil) return;
 
+      rootview = [rootview superview];
       [rootview performSelector:@selector(setReactPreferredFocusedView:) withObject:self];
       [rootview setNeedsFocusUpdate];
       [rootview updateFocusIfNeeded];
-    });
+   });
   }
 }
 


### PR DESCRIPTION
This fixes a bug that occurs when the navigator pops a current view while the focus is being updated. The code snippet below would be stuck in an infinite loop trying to find `[rootview isReactRootView]` when the rootview object is nil. 

```
while(![rootview isReactRootView]) {
   rootview = [rootview superview];
}
```

Therefore my code simply breaks out when the rootView is nil and returns out of the function without completing the rest of the logic to update focus on popped views.  
